### PR TITLE
Define the num_cpus in the ray.init call, too.

### DIFF
--- a/src/spelunker.py
+++ b/src/spelunker.py
@@ -587,7 +587,7 @@ class load:
             popt, pcov = opt.curve_fit(gaussian_2d, (xx, yy), datar, p0=initial_guess, maxfev = 500000)
             return popt
     
-        ray.init(ignore_reinit_error=True)
+        ray.init(ignore_reinit_error=True, num_cpus = ncpus)
         
         x = np.linspace(0, 7, 8)
         y = np.linspace(0, 7, 8)


### PR DESCRIPTION
For some users (me included), the code might hang if `ray.init` doesn't include the number of CPUs/threads to use as well (as in, e.g., [here](https://github.com/ray-project/ray/issues/31897)). In the future, if someone wants to use _GPUs_ instead this is something that needs to be modified too.